### PR TITLE
Added Thomas's own compute_dir_index function.

### DIFF
--- a/dirtools.py
+++ b/dirtools.py
@@ -368,6 +368,32 @@ class DirState(object):
             return cls(state=json.loads(f.read()))
 
 
+def compute_dir_index(path, hash=False):
+    """ Return a tuple containing:
+    - list of files (relative to path)
+    - lisf of subdirs (relative to path)
+    - a dict: filepath => last or optionally hash
+    """
+    files = []
+    subdirs = []
+
+    for root, dirs, filenames in os.walk(path):
+        for subdir in dirs:
+            subdirs.append(os.path.relpath(os.path.join(root, subdir), path))
+
+        for f in filenames:
+            files.append(os.path.relpath(os.path.join(root, f), path))
+        
+    index = {}
+    for f in files:
+        if hash:
+            index[f] = filehash(os.path.join(path, f))
+        else:
+            index[f] = os.path.getmtime(os.path.join(path, f))
+
+    return dict(files=files, subdirs=subdirs, index=index)
+
+	
 def compute_diff(dir_base, dir_cmp):
     """ Compare `dir_base' and `dir_cmp' and returns a list with
     the following keys:


### PR DESCRIPTION
Added Thomas's own compute_dir_index function with one correction and
one addition.
Correction:
index[f] = os.path.getmtime(os.path.join(path, files[0]))
index[f] = os.path.getmtime(os.path.join(path, f))
Addition:
Optionally use hash for indexing.
